### PR TITLE
feat: add endpoint to get cluster data and statistics

### DIFF
--- a/alembic/versions/e349512e66c3_add_cluster_table.py
+++ b/alembic/versions/e349512e66c3_add_cluster_table.py
@@ -1,0 +1,78 @@
+"""Add cluster table
+
+Revision ID: e349512e66c3
+Revises: f0a0992248c9
+Create Date: 2023-09-11 15:48:20.797850
+
+"""
+from alembic import op
+from sqlalchemy import Column, String, Integer, text
+from sqlalchemy.orm import declarative_base, Session
+
+
+# revision identifiers, used by Alembic.
+revision = 'e349512e66c3'
+down_revision = 'f0a0992248c9'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'cluster',
+        Column('name', String(length=50), primary_key=True, nullable=False),
+        Column('description', String(length=300), nullable=True),
+        Column('division', String(length=50), nullable=False),
+        Column(
+            'previous_sold_quantity',
+            Integer,
+            nullable=False,
+            server_default=text('0'),
+        )
+    )
+
+    op.execute(
+        'INSERT INTO cluster (name, division) '
+        'SELECT DISTINCT cluster, division FROM product'
+    )
+    op.drop_column('product', 'division')
+    op.create_foreign_key('fk_product_cluster', 'product', 'cluster', ['cluster'], ['name'])
+    op.create_unique_constraint(
+        'uc_product_cluster_country',
+        'product',
+        ['name', 'cluster', 'country'],
+    )
+
+
+Base = declarative_base()
+
+
+class Cluster(Base):
+    __tablename__ = 'cluster'
+    name = Column(String(length=50), primary_key=True, nullable=False)
+    division = Column(String(length=50), nullable=False)
+
+
+def downgrade() -> None:
+    op.add_column(
+        'product',
+        Column('division', String(length=50), nullable=False, server_default='temp'),
+    )
+
+    bind = op.get_bind()
+    session = Session(bind)
+    clusters = session.query(Cluster).all()
+    for clust in clusters:
+        op.execute(
+            f"UPDATE product SET division = '{clust.division}' "
+            f"WHERE cluster = '{clust.name}';"
+        )
+
+    op.drop_constraint('fk_product_cluster', 'product')
+    op.drop_table('cluster')
+    op.drop_constraint('uc_product_cluster_country', 'product')
+    op.create_unique_constraint(
+        'uc_product_cluster_division_country',
+        'product',
+        ['name', 'cluster', 'division', 'country'],
+    )

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,2 @@
+response_500 = {'description': 'Failed to retrieve data from the database', 'model': str}
+response_404 = {'description': 'No data were found for given parameters', 'model': str}

--- a/api/cluster.py
+++ b/api/cluster.py
@@ -1,0 +1,57 @@
+import pandas as pd
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+from loguru import logger
+from sqlalchemy.exc import SQLAlchemyError
+
+from api import response_404, response_500
+from calculations import percentage_increase
+from database.queries import read_cluster_data, read_products
+from schemas.cluster import Cluster
+
+router = APIRouter()
+
+
+@router.get(
+    '/{name}',
+    response_model=Cluster,
+    responses={500: response_500, 404: response_404},
+)
+def get_cluster_data(
+        name: str,
+        request: Request,
+) -> Cluster | JSONResponse:
+    logger.info(f'Received request to get cluster data for {name}.')
+    try:
+        cluster_data = read_cluster_data(request.state.db, name)
+        products = read_products(request.state.db, name)
+    except SQLAlchemyError:
+        error_msg = f'Failed to retrieve cluster data from the database for: {name}'
+        logger.error(error_msg)
+        return JSONResponse(status_code=500, content=error_msg)
+
+    if not products or not cluster_data:
+        error_msg = f'No data were found for cluster: {name}'
+        logger.error(error_msg)
+        return JSONResponse(status_code=404, content=error_msg)
+
+    products_df = pd.DataFrame({
+        'name': p.name,
+        'local_price': p.local_price,
+        'sold_quantity': p.sold_quantity,
+    } for p in products)
+    products_df['net_sales'] = products_df['sold_quantity'] * products_df['local_price']
+    total_sold_quantity = products_df['sold_quantity'].sum()
+    cluster_sales_increase = percentage_increase(
+        total_sold_quantity, cluster_data.previous_sold_quantity
+    )
+
+    return Cluster(
+        name=cluster_data.name,
+        description=cluster_data.description,
+        division=cluster_data.division,
+        nof_products=len(products_df['name'].unique()),
+        sold_quantity=total_sold_quantity,
+        net_sales=round(products_df['net_sales'].sum(), 2),
+        sales_increase=cluster_sales_increase,
+    )

--- a/api/products.py
+++ b/api/products.py
@@ -37,10 +37,7 @@ def get_products(
         return JSONResponse(status_code=500, content=error_msg)
 
     if not products:
-        error_msg = (
-            f'No products were found for given '
-            f'parameters: {country}, {cluster}',
-        )
+        error_msg = f'No products were found for given parameters: {country}, {cluster}'
         logger.error(error_msg)
         return JSONResponse(status_code=404, content=error_msg)
 

--- a/app.py
+++ b/app.py
@@ -5,11 +5,13 @@ from fastapi.responses import Response
 
 from database.connect import db_session
 from api.products import router as product_router
+from api.cluster import router as cluster_router
 
 app = FastAPI()
 
 routers = {
     'products': product_router,
+    'cluster_data': cluster_router,
 }
 
 

--- a/calculations.py
+++ b/calculations.py
@@ -2,15 +2,20 @@ import pandas as pd
 import numpy as np
 
 
+def percentage_increase(numerator: float, denominator: float) -> float:
+    result = ((numerator / denominator) - 1) * 100 if denominator != 0 else 0.0
+    return round(result, 2)
+
+
 def calculate_local_deviation(row: pd.Series) -> float:
     if np.isnan(row['global_price']) or (row['global_price'] == 0):
         return 0.0
     else:
-        return ((row['local_price'] / row['global_price']) - 1) * 100
+        return percentage_increase(row['local_price'], row['global_price'])
 
 
 def calculate_sales_increase(row: pd.Series) -> float:
     if np.isnan(row['previous_sold_quantity']) or (row['previous_sold_quantity'] == 0):
         return 0.0
     else:
-        return ((row['sold_quantity'] / row['previous_sold_quantity']) - 1) * 100
+        return percentage_increase(row['sold_quantity'], row['previous_sold_quantity'])

--- a/database/queries.py
+++ b/database/queries.py
@@ -1,12 +1,23 @@
+from typing import Optional
+
 from sqlalchemy.orm import Session
 
 from models.product import Product
+from models.cluster import Cluster
 
 
-def read_products(db: Session, country: str, division: str, cluster: str):
-    products = db.query(Product).filter(
-        Product.country == country,
-        Product.division == division,
-        Product.cluster == cluster,
-    ).all()
+def read_products(db: Session, cluster: str, country: Optional[str] = None):
+    query_filters = [Product.cluster == cluster]
+    if country: query_filters.append(Product.country == country)
+    products = db.query(Product).filter(*query_filters).all()
     return products
+
+
+def get_cluster_division(db: Session, cluster: str):
+    division = db.query(Cluster.division).filter(Cluster.name == cluster).first()
+    return division[0]
+
+
+def read_cluster_data(db: Session, name: str):
+    cluster_data = db.query(Cluster).filter(Cluster.name == name).first()
+    return cluster_data

--- a/models/cluster.py
+++ b/models/cluster.py
@@ -1,0 +1,12 @@
+from sqlalchemy import Column, String, Integer
+
+from database.connect import Base
+
+
+class Cluster(Base):
+    __tablename__ = 'cluster'
+
+    name = Column(String(length=50), primary_key=True, nullable=False)
+    description = Column(String(length=300), nullable=True)
+    division = Column(String(length=50), nullable=False)
+    previous_sold_quantity = Column(Integer, nullable=False, default=0)

--- a/models/product.py
+++ b/models/product.py
@@ -14,7 +14,6 @@ class Product(Base):
     sold_quantity = Column(Integer, nullable=False)
     previous_sold_quantity = Column(Integer, nullable=False, default=0)
     cluster = Column(String(length=50), nullable=False)
-    division = Column(String(length=50), nullable=False)
     country = Column(String(length=50), nullable=False)
 
-    UniqueConstraint('name', 'cluster', 'division', 'country')
+    UniqueConstraint('name', 'cluster', 'country')

--- a/schemas/cluster.py
+++ b/schemas/cluster.py
@@ -1,0 +1,21 @@
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class Cluster(BaseModel):
+    name: str = Field(..., title='Product internal name', max_length=100)
+    description: Optional[str] = Field(None, title='Description', max_length=300)
+    division: str = Field(..., max_length=50)
+    nof_products: int = Field(..., title='Number of products in the cluster')
+    sold_quantity: int = Field(..., title='Quantity of products sold')
+    net_sales: float = Field(
+        ...,
+        title='Net sales',
+        description='Net value of all units sold'
+    )
+    sales_increase: float = Field(
+        ...,
+        title='Sales increase',
+        description='Increase in sales compared to previous period'
+    )

--- a/tests/integration/test_cluster.py
+++ b/tests/integration/test_cluster.py
@@ -1,0 +1,32 @@
+import pytest
+import requests
+
+from .conftest import API_URL
+
+
+@pytest.mark.parametrize(
+    'name, nof_products',
+    (
+            ('RELAY ACCESSORIES', 4),
+            ('FA ACCESSORY', 2),
+            ('VALVES AND ACTUATORS', 3),
+    )
+)
+def test_get_cluster_data(
+        name: str, nof_products: int
+) -> None:
+    response = requests.get(f'{API_URL}/cluster_data/{name}')
+
+    assert response.status_code == 200
+    cluster_data = response.json()
+    assert cluster_data['name'] == name
+    assert len(cluster_data) == 7
+    assert cluster_data['nof_products'] == nof_products
+
+
+def test_get_cluster_data_not_found() -> None:
+    response = requests.get(
+        f'{API_URL}/cluster_data/ACCESSORY',
+    )
+    assert response.status_code == 404
+    assert response.json() == 'No data were found for cluster: ACCESSORY'

--- a/tests/integration/test_products.py
+++ b/tests/integration/test_products.py
@@ -28,3 +28,11 @@ def test_get_products(
         assert product['net_sales'] == round(
             product['sold_quantity'] * product['local_price'], 2
         )
+
+
+def test_get_products_not_found() -> None:
+    response = requests.get(
+        f'{API_URL}/products/Franc/ACCESSORY',
+    )
+    assert response.status_code == 404
+    assert response.json() == 'No products were found for given parameters: Franc, ACCESSORY'

--- a/tests/integration/test_products.py
+++ b/tests/integration/test_products.py
@@ -5,17 +5,17 @@ from .conftest import API_URL
 
 
 @pytest.mark.parametrize(
-    'country, division, cluster, response_length',
+    'country, cluster, response_length',
     (
-            ('France', 'HDLSD', 'RELAY ACCESSORIES', 4),
-            ('Poland', 'HDLSD', 'FA ACCESSORY', 2),
+            ('France', 'RELAY ACCESSORIES', 4),
+            ('Poland', 'FA ACCESSORY', 2),
     )
 )
 def test_get_products(
-        country: str, division: str, cluster: str, response_length: int
+        country: str, cluster: str, response_length: int
 ) -> None:
     response = requests.get(
-        f'{API_URL}/products/{country}/{division}/{cluster}',
+        f'{API_URL}/products/{country}/{cluster}',
     )
 
     assert response.status_code == 200

--- a/tests/unit/test_calculations.py
+++ b/tests/unit/test_calculations.py
@@ -17,7 +17,7 @@ from calculations import calculate_sales_increase, calculate_local_deviation
 def test_calculate_sales_increase(row: dict, expected_increase: float) -> None:
     product_data = pd.Series(row)
     result = calculate_sales_increase(product_data)
-    assert round(result, 2) == expected_increase
+    assert result == expected_increase
 
 
 @pytest.mark.parametrize(
@@ -31,4 +31,4 @@ def test_calculate_sales_increase(row: dict, expected_increase: float) -> None:
 def test_calculate_local_deviation(row: dict, expected_deviation: float) -> None:
     product_data = pd.Series(row)
     result = calculate_local_deviation(product_data)
-    assert round(result, 2) == expected_deviation
+    assert result == expected_deviation


### PR DESCRIPTION
closes #5 

An endpoint `GET /cluster_data/{name}` was implemented in order to return cluster data and sales statistics.
Response schema:
```
{
  "name": "string",
  "description": "string",
  "division": "string",
  "nof_products": int,
  "sold_quantity": int,
  "net_sales": float,
  "sales_increase": float
}
```

For the fields `nof_products`, `sold_quantity`,  `net_sales`, `sales_increase` corresponding calculations were implemented based on products' aggregated data.

In the scope of this change, required data models, alembic revision and integration tests were created.